### PR TITLE
Add fractional second parsing for logs/etc.

### DIFF
--- a/fuzzy_test.go
+++ b/fuzzy_test.go
@@ -60,8 +60,11 @@ func TestDateTimes(t *testing.T) {
 		{"May 2008", "2008-05"},
 
 		// fractional seconds
-		{"21:59:59.9942", "T21:59:59"},
-		{"21:59:59.9942GMT", "T21:59:59Z"},
+		{"21:59:59.994222", "T21:59:59.994222"},
+		{"21:59:59.9942", "T21:59:59.9942"},
+		{"21:59:59,994", "T21:59:59.994"},
+		{"21:59:59,99", "T21:59:59.99"},
+		{"21:59:59.9942GMT", "T21:59:59.9942Z"},
 
 		// tricky ones where hour can get picked up as year if not careful!
 		{"Thu Aug 25 10:46:55 GMT 2011", "2011-08-25T10:46:55Z"},       // (www.yorkshireeveningpost.co.uk)
@@ -119,7 +122,7 @@ func TestDateTimes(t *testing.T) {
 	for _, dat := range testData {
 		dt, _, _ := Extract(dat.in)
 		//if err != nil {
-		// t.Errorf("Extract(%s) failed: %s", dat.in, err)
+		//	t.Errorf("Extract(%s) failed: %s", dat.in, err)
 		//}
 		got := dt.ISOFormat()
 		if got != dat.expected {

--- a/fuzzy_test.go
+++ b/fuzzy_test.go
@@ -60,11 +60,8 @@ func TestDateTimes(t *testing.T) {
 		{"May 2008", "2008-05"},
 
 		// fractional seconds
-		{"21:59:59.994222", "T21:59:59.994222"},
-		{"21:59:59.9942", "T21:59:59.9942"},
 		{"21:59:59,994", "T21:59:59.994"},
-		{"21:59:59,99", "T21:59:59.99"},
-		{"21:59:59.9942GMT", "T21:59:59.9942Z"},
+		{"21:59:59.994GMT", "T21:59:59.994Z"},
 
 		// tricky ones where hour can get picked up as year if not careful!
 		{"Thu Aug 25 10:46:55 GMT 2011", "2011-08-25T10:46:55Z"},       // (www.yorkshireeveningpost.co.uk)

--- a/time.go
+++ b/time.go
@@ -132,7 +132,7 @@ func (t *Time) String() string {
 		second = fmt.Sprintf("%02d", t.Second())
 	}
 	if t.HasFractional() {
-		fractional = fmt.Sprintf(".%d", t.Fractional())
+		fractional = fmt.Sprintf(".%03d", t.Fractional())
 	}
 	if t.HasTZOffset() {
 		tz = OffsetToTZ(t.TZOffset())
@@ -153,7 +153,7 @@ func (t *Time) ISOFormat() string {
 			if t.HasSecond() {
 				if t.HasFractional() {
 					out = fmt.Sprintf(
-						"%02d:%02d:%02d.%d",
+						"%02d:%02d:%02d.%03d",
 						t.Hour(),
 						t.Minute(),
 						t.Second(),

--- a/time_parse.go
+++ b/time_parse.go
@@ -27,15 +27,15 @@ var timeCrackers = []*regexp.Regexp{
 	// "15:29 GMT"
 	// "12:35:44+00:00"
 	// "23:59:59.9942+01:00"
-	regexp.MustCompile(`(?i)(?:\b|T)(?P<hour>\d{1,2})[:](?P<min>\d{2})(?:[:](?P<sec>\d{2})(?:[.,](?P<fractional>\d+))?)?[\s\p{Z}]*` + tzPat),
+	regexp.MustCompile(`(?i)(?:\b|T)(?P<hour>\d{1,2})[:](?P<min>\d{2})(?:[:](?P<sec>\d{2})(?:[.,](?P<fractional>\d{3}))?)?[\s\p{Z}]*` + tzPat),
 
 	// "00.01 BST"
 	regexp.MustCompile(`(?i)(?:\b|T)(?P<hour>\d{1,2})[.](?P<min>\d{2})(?:[.](?P<sec>\d{2}))?[\s\p{Z}]*` + tzPat),
 
 	// "14:21:01"
 	// "14:21"
-	// "23:59:59.9942"
-	regexp.MustCompile(`(?i)(?:\b|T)(?P<hour>\d{1,2})[:](?P<min>\d{2})(?:[:](?P<sec>\d{2})(?:[.,](?P<fractional>\d+))?)?(?:[^\d]|\z)`),
+	// "23:59:59.994"
+	regexp.MustCompile(`(?i)(?:\b|T)(?P<hour>\d{1,2})[:](?P<min>\d{2})(?:[:](?P<sec>\d{2})(?:[.,](?P<fractional>\d{3}))?)?(?:[^\d]|\z)`),
 }
 
 // ExtractTime tries to parse a time from a string.
@@ -117,7 +117,7 @@ func (ctx *Context) ExtractTime(s string) (Time, Span, error) {
 					fail = err
 					break
 				}
-				if fractional < 0 || fractional > 999999 {
+				if fractional < 0 || fractional > 999 {
 					fail = errors.New("bad fractional seconds value")
 					break
 				}


### PR DESCRIPTION
Great project!  I'd love to be able to use this for untangling some issues with logs and not knowing the datetime formats coming my way.  This PR adds fractional second support and some tests to ensure it's working through micro-second granularity.

I tried to keep in it the style of the package.  Please let me know if you'd like me to clean up anything.  Thanks for working on fuzzytime!